### PR TITLE
Fix pairwise formula

### DIFF
--- a/quadratic-funding/clr.py
+++ b/quadratic-funding/clr.py
@@ -181,7 +181,7 @@ def calculate_clr(aggregated_contributions, pair_totals, threshold, total_pot):
             for k2, v2 in contribz.items():
                 if k2 > k1:
                     # quadratic formula
-                    tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] / (threshold + 1))
+                    tot += ((v1 * v2) ** 0.5) / (pair_totals[k1][k2] + threshold))
 
         if type(tot) == complex:
             tot = float(tot.real)


### PR DESCRIPTION
See Vitalik's [pairwise formula article](https://ethresear.ch/t/pairwise-coordination-subsidies-a-new-quadratic-funding-design/5553):
<img width="572" alt="image" src="https://user-images.githubusercontent.com/29608734/167045777-7741cd03-62ab-4878-9150-3655b6739a35.png">

Here, `M` is `threshold` and it should be summed up with the pairwise sum rather than divided.

Otherwise, as in your code, `threshold` doesn't have any meaning and no matter what value you provide for it, it will always produce the same result.